### PR TITLE
chore: bump minimum Node.js engine to 22.22.2 and update documentatio…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ is the upstream itself.
 ## Style and conventions
 
 - TypeScript `strict: true`, `target: ES2022`, `module: Node16`. The
-  build emits `.js` + `.d.ts` + source maps. The runtime is Node 18+.
+  build emits `.js` + `.d.ts` + source maps. The runtime is Node 22.22.2+.
 - ESM imports use the explicit `.js` extension even when the source
   is `.ts` (Node16 module-resolution requirement).
 - Avoid adding new runtime dependencies without a strong reason — the

--- a/README.md
+++ b/README.md
@@ -77,9 +77,17 @@ Click any screenshot to view full resolution.
 
 ## Prerequisites
 
-- **Node.js** >= 18 (LTS recommended)
+- **Node.js** >= 22.22.2 (required by transitive dependencies)
 - **npm** or **bun** or **pnpm**
 - **OpenCode CLI** installed and configured with a Go subscription (Zen is optional but recommended)
+
+> **npm EACCES error?** If `npm install -g` fails with `permission denied`, configure npm to use a user-writable global prefix:
+> ```bash
+> npm config set prefix ~/.npm-global
+> echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc
+> source ~/.bashrc
+> ```
+> Then re-run the install. Alternatively, use [nvm](https://github.com/nvm-sh/nvm) which handles this automatically.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.22.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
…n with npm EACCES troubleshooting steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Node.js requirement to **22.22.2+** across project setup guidance.
  * Added a troubleshooting tip for resolving **npm permission (EACCES)** issues during global installs.

* **Chores**
  * Aligned the package engine requirement with the new supported Node.js version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->