### PR TITLE
fix(proxy): do not open every circuit breaker on a repeated upstream 5xx

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -139,6 +139,12 @@ export class ProxyServer {
       ?? (getHeader(headers, 'prompt-cache-key') ? createProxySessionId(getHeader(headers, 'prompt-cache-key')!) : undefined)
 
     const attemptedKeyIds = new Set<string>()
+    // A 5xx that repeats on a second key is a property of the request or the
+    // upstream, not of the key: the same body failed the same way with
+    // different credentials. Only the first 5xx of a request counts against a
+    // key's circuit breaker, so one unroutable model cannot open every breaker
+    // in the pool and take healthy keys out of rotation for unrelated traffic.
+    let upstreamServerErrorSeen = false
     const totalKeys = this.keyManager.getActiveKeys().length
     const maxAttempts = totalKeys || 1
     let lastError = 'All API keys exhausted'
@@ -273,8 +279,14 @@ export class ProxyServer {
         }
 
         if (upstreamRes.status >= 500) {
-          const circuitState = this.circuitBreaker.recordFailure(key.id)
-          this.keyManager.markError(key.id)
+          const repeatedServerError = upstreamServerErrorSeen
+          upstreamServerErrorSeen = true
+          const circuitState = repeatedServerError
+            ? this.circuitBreaker.getState(key.id)
+            : this.circuitBreaker.recordFailure(key.id)
+          if (!repeatedServerError) {
+            this.keyManager.markError(key.id)
+          }
           this.keyManager.recordRequest(key.id, {
             statusCode: upstreamRes.status,
             durationMs: duration,


### PR DESCRIPTION
## Problem

A single request for a model the upstream cannot serve takes the whole key pool out of rotation.

When an upstream returns 5xx, the proxy calls `circuitBreaker.recordFailure(key.id)` and fails over to the next key. If the 5xx is deterministic — a bad model id, or an upstream route that is broken for one model class — every key in the pool gets a failure recorded for the same request. At the default threshold of 3, three such requests open all breakers, and keys that were never unhealthy stop serving unrelated traffic.

Observed against the Zen upstream: `POST /zen/v1/chat/completions` returns 500 for the muse contributor models. A few probes for one of those models opened all three breakers, after which requests to the Go upstream — a different upstream, unrelated to the failure — also failed with `Service Unavailable: All API keys failed` until each key was reset by hand via `POST /api/keys/:id/reset-cooldown`.

The message is misleading too: the keys had not failed, and `quotaErrorCount` stayed 0.

## Change

Within one request's failover loop, only the FIRST 5xx counts against a key's circuit breaker. A 5xx that repeats on a second key is evidence about the request or the upstream rather than about the key — the same body failed the same way under different credentials.

Failover behaviour is unchanged: the request is still retried across keys and the client still gets the same response. Only the per-key health accounting changes, so a genuine single-key fault still trips its breaker exactly as before.

## Verification

Built and running against a live router.

Before: three requests for an unroutable model → all three keys `status: cooldown`, and Go-upstream traffic failing.

After: the same three requests → all three keys `status: active`, and `opencode-go/muse-spark-1.3-contributor` answers normally on the next request.

`npm run typecheck` passes.
