### PR TITLE
feat(proxy): fall back to the Responses API for Zen models that need it

### DIFF
--- a/src/proxy/response-parser.ts
+++ b/src/proxy/response-parser.ts
@@ -36,9 +36,9 @@ function extractUsageObject(source: Record<string, any> | undefined): ParsedUsag
   const tokens: TokenBreakdown = {
     input: source.input_tokens ?? source.prompt_tokens ?? 0,
     output: source.output_tokens ?? source.completion_tokens ?? 0,
-    cacheRead: source.cache_read_input_tokens ?? source.prompt_tokens_details?.cached_tokens ?? 0,
+    cacheRead: source.cache_read_input_tokens ?? source.prompt_tokens_details?.cached_tokens ?? source.input_tokens_details?.cached_tokens ?? 0,
     cacheWrite: source.cache_creation_input_tokens ?? 0,
-    reasoning: source.reasoning_output_tokens ?? source.completion_tokens_details?.reasoning_tokens ?? 0,
+    reasoning: source.reasoning_output_tokens ?? source.completion_tokens_details?.reasoning_tokens ?? source.output_tokens_details?.reasoning_tokens ?? 0,
   }
 
   const rawCost = source.cost ?? source.total_cost ?? source.estimated_cost
@@ -67,6 +67,13 @@ function parseJsonUsage(json: unknown): ParsedUsageData | null {
 
   if (value.type === 'message_delta' && value.usage) {
     usage = mergeUsage(usage, extractUsageObject(value.usage))
+  }
+
+  // The Responses API delivers usage inside response.completed, nested under
+  // response.usage. The non-streaming path already catches it via the top-level
+  // usage branch above; the streaming path lands here.
+  if (value.type === 'response.completed' && value.response?.usage) {
+    usage = mergeUsage(usage, extractUsageObject((value.response as Record<string, any>).usage))
   }
 
   if (value.message?.usage) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -15,6 +15,7 @@ import {
   type QuotaErrorSignal,
 } from '../router/types.js'
 import { buildUpstreamHeaders, extractCacheHeaders } from './header-passthrough.js'
+import { isChatCompletionsPath, toResponsesPath, toResponsesRequestBody, toChatCompletion, SseTranslator } from './zen-responses.js'
 import { isQuota429, resolveCooldownMs } from './quota-detector.js'
 import { parseUsageData } from './response-parser.js'
 import { estimateCost } from './rate-card.js'
@@ -83,6 +84,10 @@ export class ProxyServer {
   private server?: http.Server
   private readonly config: ProxyServerConfig
   private readonly sessionAffinity: SessionAffinityStore
+  // Models whose native zen chat/completions route 500s and that therefore
+  // must use the Responses API. Learned on the first 500 per model per
+  // process; a restart forgets it and re-learns if Zen ever fixes the route.
+  private readonly zenResponsesModelMemo = new Map<string, boolean>()
 
   constructor(
     config: ProxyServerConfig,
@@ -119,6 +124,13 @@ export class ProxyServer {
     if (isZenRequest && req.url) {
       req.url = req.url.replace(/^\/zen(\/|$)/, '/')
     }
+    // Zen's free models are split: some serve only chat/completions (laguna,
+    // nemotron), others only the Responses API (the muse contributor models).
+    // Unknown models start native and are switched to /responses only when the
+    // upstream proves their chat/completions route is dead; a model remembered
+    // here is translated up front so it pays no second round trip.
+    let translateZenResponses = false
+    let includeUsage = false
     const headers = req.headers as Record<string, string | string[] | undefined>
     const body = await this.readBody(req)
     if (body === null) {
@@ -132,7 +144,20 @@ export class ProxyServer {
       return
     }
 
-    const prepared = this.prepareRequest(body, targetPath)
+    let requestBody = body
+    const isZenChatCompletions = isZenRequest && req.method === 'POST' && req.url && isChatCompletionsPath(req.url.split('?')[0])
+    const requestModel = this.extractModelName(body)
+    if (isZenChatCompletions && requestModel && req.url && this.zenResponsesModelMemo.has(requestModel)) {
+      const translatedBody = toResponsesRequestBody(body)
+      if (translatedBody) {
+        requestBody = translatedBody
+        req.url = toResponsesPath(req.url)
+        translateZenResponses = true
+        includeUsage = this.bodyRequestsUsage(body)
+      }
+    }
+
+    let prepared = this.prepareRequest(requestBody, targetPath)
     const cacheHeaders = extractCacheHeaders(headers)
     const sessionKey = this.sessionAffinity.extractSessionKey(headers)
     const upstreamSessionId = getHeader(headers, 'x-session-id')
@@ -194,7 +219,7 @@ export class ProxyServer {
       }
 
       const startTime = Date.now()
-      const upstreamHungTimer = this.config.upstreamHungTimeoutMs > 0
+      let upstreamHungTimer = this.config.upstreamHungTimeoutMs > 0
         ? setTimeout(() => {
             if (!upstreamAbortController.signal.aborted) {
               upstreamAbortController.abort(new Error('upstream hung (no response within UPSTREAM_HUNG_TIMEOUT_MS)'))
@@ -204,7 +229,7 @@ export class ProxyServer {
 
       try {
         const fetchUrl = buildUpstreamUrl(upstreamUrl, req.url)
-        const upstreamRes = await fetch(fetchUrl, {
+        let upstreamRes = await fetch(fetchUrl, {
           method: req.method ?? 'GET',
           headers: upstreamHeaders,
           body: req.method !== 'GET' && req.method !== 'HEAD' ? prepared.body : undefined,
@@ -212,8 +237,63 @@ export class ProxyServer {
         })
         if (upstreamHungTimer) clearTimeout(upstreamHungTimer)
 
-        const duration = Date.now() - startTime
-        const responseTextPromise = upstreamRes.clone().text().catch(() => '')
+        let duration = Date.now() - startTime
+        let responseTextPromise = upstreamRes.clone().text().catch(() => '')
+
+        // A zen chat/completions request that 500s on its native endpoint may
+        // belong to a model only the Responses API can serve (the free
+        // contributor models). Retry ONCE in translated form on the SAME key:
+        // a protocol switch is not a key failure, so it must not consume a
+        // key-failover attempt. The per-model memo makes this a one-time cost
+        // per model per process.
+        if (upstreamRes.status >= 500 && isZenChatCompletions && !translateZenResponses && requestModel && req.url) {
+          const translatedBody = toResponsesRequestBody(body)
+          if (translatedBody) {
+            requestBody = translatedBody
+            req.url = toResponsesPath(req.url)
+            translateZenResponses = true
+            includeUsage = this.bodyRequestsUsage(body)
+            prepared = this.prepareRequest(requestBody, targetPath)
+            upstreamRes.body?.cancel().catch(() => {})
+            this.logStream.emit(this.logger, 'warn',
+              `Zen chat/completions 500 for "${requestModel}" - retrying via /responses on "${key.alias}"`, {
+                method: req.method,
+                path: targetPath,
+                statusCode: 500,
+                keyAlias: key.alias,
+                keyId: key.id,
+                model: requestModel,
+                strategy,
+                routeReason: reason,
+                upstream: 'zen',
+              })
+            if (this.config.upstreamHungTimeoutMs > 0) {
+              upstreamHungTimer = setTimeout(() => {
+                if (!upstreamAbortController.signal.aborted) {
+                  upstreamAbortController.abort(new Error('upstream hung (no response within UPSTREAM_HUNG_TIMEOUT_MS)'))
+                }
+              }, this.config.upstreamHungTimeoutMs)
+            }
+            const translatedFetchUrl = buildUpstreamUrl(upstreamUrl, req.url)
+            const translatedRes = await fetch(translatedFetchUrl, {
+              method: req.method ?? 'GET',
+              headers: upstreamHeaders,
+              body: req.method !== 'GET' && req.method !== 'HEAD' ? prepared.body : undefined,
+              signal: upstreamAbortController.signal,
+            })
+            if (upstreamHungTimer) clearTimeout(upstreamHungTimer)
+            // Only a translated attempt that is not itself a 5xx proves the
+            // model needs the Responses endpoint. If it also 5xxes the failure
+            // is more likely the key, so the model stays unremembered and the
+            // next request starts native again.
+            if (translatedRes.status < 500) {
+              this.zenResponsesModelMemo.set(requestModel, true)
+            }
+            upstreamRes = translatedRes
+            duration = Date.now() - startTime
+            responseTextPromise = translatedRes.clone().text().catch(() => '')
+          }
+        }
 
         if (upstreamRes.status === 402 || upstreamRes.status === 429) {
           const responseBody = await responseTextPromise
@@ -308,11 +388,21 @@ export class ProxyServer {
         }
 
         const responseHeaders = this.buildResponseHeaders(upstreamRes)
-        res.writeHead(upstreamRes.status, responseHeaders)
-        if (upstreamRes.body) {
-          await this.pipeResponseBody(upstreamRes.body, res)
+        if (translateZenResponses && upstreamRes.status < 400 && upstreamRes.body) {
+          res.writeHead(upstreamRes.status, responseHeaders)
+          if (prepared.stream) {
+            await this.pipeTranslatedZenStream(upstreamRes.body, res, includeUsage)
+          } else {
+            const raw = await upstreamRes.clone().text().catch(() => '')
+            res.end(toChatCompletion(raw))
+          }
         } else {
-          res.end()
+          res.writeHead(upstreamRes.status, responseHeaders)
+          if (upstreamRes.body) {
+            await this.pipeResponseBody(upstreamRes.body, res)
+          } else {
+            res.end()
+          }
         }
 
         const responseBody = await responseTextPromise
@@ -474,6 +564,27 @@ export class ProxyServer {
     }
   }
 
+  // Whether the caller opted into usage reporting on a streaming request.
+  // The translated Responses request does not carry stream_options, so the
+  // original chat/completions body is the only place this signal survives.
+  private bodyRequestsUsage(body: Buffer): boolean {
+    try {
+      const json = JSON.parse(body.toString('utf8')) as Record<string, unknown>
+      return Boolean(typeof json.stream_options === 'object' && json.stream_options && (json.stream_options as Record<string, unknown>).include_usage)
+    } catch {
+      return false
+    }
+  }
+
+  private extractModelName(body: Buffer): string | null {
+    try {
+      const json = JSON.parse(body.toString('utf8')) as Record<string, unknown>
+      return typeof json.model === 'string' && json.model.length > 0 ? json.model : null
+    } catch {
+      return null
+    }
+  }
+
   private buildResponseHeaders(upstreamRes: Response): Record<string, string> {
     const responseHeaders: Record<string, string> = {}
     upstreamRes.headers.forEach((value, key) => {
@@ -488,6 +599,62 @@ export class ProxyServer {
       }
     })
     return responseHeaders
+  }
+
+  /** Pipe a Zen Responses SSE stream to the client as chat.completion.chunk frames. */
+  private async pipeTranslatedZenStream(body: ReadableStream<Uint8Array>, res: http.ServerResponse, includeUsage = false): Promise<void> {
+    const reader = body.getReader()
+    const translator = new SseTranslator(includeUsage)
+    const decoder = new TextDecoder()
+    let buffered = ''
+
+    const processEvent = (rawEvent: string) => {
+      let eventName = ''
+      const dataLines: string[] = []
+      for (const line of rawEvent.split('\n')) {
+        if (line.startsWith('event:')) eventName = line.slice(6).trim()
+        else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim())
+      }
+      // Multiple data: lines in one event are concatenated with '\n' per the
+      // SSE spec; a JSON payload split across lines reconstructs correctly.
+      const data = dataLines.join('\n')
+      if (eventName && data) {
+        const out = translator.translate(eventName, data)
+        if (out) res.write(out)
+      }
+    }
+
+    const processBuffer = () => {
+      let boundary = buffered.indexOf('\n\n')
+      while (boundary !== -1) {
+        const rawEvent = buffered.slice(0, boundary)
+        buffered = buffered.slice(boundary + 2)
+        processEvent(rawEvent)
+        boundary = buffered.indexOf('\n\n')
+      }
+    }
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        // Normalise CRLF before splitting on \n\n so a \r\n-stream frames the
+        // same way as an \n-stream.
+        buffered += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n')
+        processBuffer()
+      }
+      // Flush any remaining multi-byte sequence from the decoder, then treat
+      // whatever is still in the buffer (no trailing blank line) as a final
+      // event. A response.completed that arrives at stream end without \n\n
+      // would otherwise be silently dropped, leaving the client without
+      // finish_reason or [DONE].
+      buffered += decoder.decode()
+      processBuffer()
+      if (buffered.trim()) processEvent(buffered)
+      res.end()
+    } catch {
+      res.end()
+    }
   }
 
   private async pipeResponseBody(body: ReadableStream<Uint8Array>, res: http.ServerResponse): Promise<void> {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -129,8 +129,8 @@ export class ProxyServer {
     // Unknown models start native and are switched to /responses only when the
     // upstream proves their chat/completions route is dead; a model remembered
     // here is translated up front so it pays no second round trip.
-    let translateZenResponses = false
-    let includeUsage = false
+    let translateZenResponses: boolean = false
+    let includeUsage: boolean = false
     const headers = req.headers as Record<string, string | string[] | undefined>
     const body = await this.readBody(req)
     if (body === null) {
@@ -245,10 +245,18 @@ export class ProxyServer {
         // contributor models). Retry ONCE in translated form on the SAME key:
         // a protocol switch is not a key failure, so it must not consume a
         // key-failover attempt. The per-model memo makes this a one-time cost
-        // per model per process.
-        if (upstreamRes.status >= 500 && isZenChatCompletions && !translateZenResponses && requestModel && req.url) {
+        // per model per process. Only an exact 500 triggers this: 502/503/504
+        // are transient infra failures that fail over to the next key.
+        if (upstreamRes.status === 500 && isZenChatCompletions && !translateZenResponses && requestModel && req.url) {
           const translatedBody = toResponsesRequestBody(body)
           if (translatedBody) {
+            // Per-attempt snapshot: if the translated attempt also fails, the
+            // next key must start native again, not inherit the /responses URL.
+            const attemptUrl: string = req.url
+            const attemptBody: Buffer = requestBody
+            const attemptPrepared: RequestPreparation = prepared
+            const attemptTranslated: boolean = translateZenResponses
+            const attemptIncludeUsage: boolean = includeUsage
             requestBody = translatedBody
             req.url = toResponsesPath(req.url)
             translateZenResponses = true
@@ -282,12 +290,19 @@ export class ProxyServer {
               signal: upstreamAbortController.signal,
             })
             if (upstreamHungTimer) clearTimeout(upstreamHungTimer)
-            // Only a translated attempt that is not itself a 5xx proves the
-            // model needs the Responses endpoint. If it also 5xxes the failure
-            // is more likely the key, so the model stays unremembered and the
-            // next request starts native again.
-            if (translatedRes.status < 500) {
+            // Only a translated 2xx proves the model needs the Responses
+            // endpoint. A 4xx (translation bug, bad key, quota) or a further
+            // 5xx must not pin the model: the next request starts native
+            // again. On a 5xx the per-attempt state is restored so the next
+            // key is tried natively, not forced down the translated path.
+            if (translatedRes.ok) {
               this.zenResponsesModelMemo.set(requestModel, true)
+            } else if (translatedRes.status >= 500) {
+              req.url = attemptUrl
+              requestBody = attemptBody
+              prepared = attemptPrepared
+              translateZenResponses = attemptTranslated
+              includeUsage = attemptIncludeUsage
             }
             upstreamRes = translatedRes
             duration = Date.now() - startTime
@@ -393,8 +408,9 @@ export class ProxyServer {
           if (prepared.stream) {
             await this.pipeTranslatedZenStream(upstreamRes.body, res, includeUsage)
           } else {
-            const raw = await upstreamRes.clone().text().catch(() => '')
-            res.end(toChatCompletion(raw))
+            const translatedBody = await responseTextPromise
+            res.end(toChatCompletion(translatedBody))
+            responseTextPromise = Promise.resolve(translatedBody)
           }
         } else {
           res.writeHead(upstreamRes.status, responseHeaders)

--- a/src/proxy/zen-responses.ts
+++ b/src/proxy/zen-responses.ts
@@ -11,13 +11,15 @@
 const CHAT_COMPLETIONS_SUFFIX = '/chat/completions'
 
 export function isChatCompletionsPath(path: string): boolean {
-  return path.endsWith(CHAT_COMPLETIONS_SUFFIX)
+  return path.replace(/\/+$/, '').endsWith(CHAT_COMPLETIONS_SUFFIX)
 }
 
 /** Rewrite `/zen/v1/chat/completions` -> `/zen/v1/responses`, query preserved. */
 export function toResponsesPath(url: string): string {
   const [path, ...rest] = url.split('?')
-  const rewritten = path.slice(0, -CHAT_COMPLETIONS_SUFFIX.length) + '/responses'
+  const stripped = path.replace(/\/+$/, '')
+  if (!stripped.endsWith(CHAT_COMPLETIONS_SUFFIX)) return url
+  const rewritten = stripped.slice(0, -CHAT_COMPLETIONS_SUFFIX.length) + '/responses'
   return rest.length ? `${rewritten}?${rest.join('?')}` : rewritten
 }
 
@@ -38,9 +40,15 @@ export function toResponsesRequestBody(body: Buffer): Buffer | null {
   const messages = parsed.messages
   if (!Array.isArray(messages)) return null
 
+  const input = toResponsesInput(messages)
+  // Null means a message part has no Responses equivalent (e.g. an
+  // image_url or other non-text content part we cannot translate). Fail open
+  // so the caller forwards the request natively instead of sending a
+  // mistranslated body that the upstream would 400.
+  if (!input) return null
   const translated: Record<string, unknown> = {
     model: parsed.model,
-    input: toResponsesInput(messages),
+    input,
   }
   // The Responses API names the output budget differently. Both are passed
   // through verbatim: a caller's budget is the caller's choice, even though
@@ -48,9 +56,14 @@ export function toResponsesRequestBody(body: Buffer): Buffer | null {
   if (parsed.max_tokens != null) translated.max_output_tokens = parsed.max_tokens
   if (parsed.max_completion_tokens != null) translated.max_output_tokens = parsed.max_completion_tokens
   if (parsed.max_output_tokens != null) translated.max_output_tokens = parsed.max_output_tokens
-  for (const key of ['temperature', 'top_p', 'stream', 'metadata']) {
+  for (const key of ['temperature', 'top_p', 'stream', 'metadata', 'parallel_tool_calls']) {
     if (parsed[key] !== undefined) translated[key] = parsed[key]
   }
+  // Intentionally not forwarded: stop, seed, frequency_penalty,
+  // presence_penalty, logit_bias, logprobs/top_logprobs, n, user, store and
+  // service_tier have no Responses API equivalent, and forwarding unknown
+  // fields risks an upstream 400. Translated requests therefore behave as the
+  // defaults for those parameters.
   // chat/completions object-form tool_choice nests the name under `function`,
   // the same shape the tools array uses just below; the Responses API flattens
   // it onto the choice. String forms mean the same in both APIs and pass
@@ -106,13 +119,17 @@ export function toResponsesRequestBody(body: Buffer): Buffer | null {
 /**
  * chat/completions `messages` -> Responses `input`.
  *
- * Plain messages pass through unchanged. The two that cannot are an assistant
- * turn carrying `tool_calls` and a `role: "tool"` result: the Responses API
- * models those as standalone `function_call` / `function_call_output` items
- * rather than as message fields, so a conversation replayed without this
- * translation loses every tool exchange.
+ * Plain messages pass through with their text/image content translated (see
+ * toResponsesContent). The two shapes that cannot pass through are an
+ * assistant turn carrying `tool_calls` and a `role: "tool"` result: the
+ * Responses API models those as standalone `function_call` /
+ * `function_call_output` items rather than as message fields, so a
+ * conversation replayed without this translation loses every tool exchange.
+ *
+ * Returns null when any message part has no Responses equivalent, so the
+ * caller can fail open and forward the request natively.
  */
-function toResponsesInput(messages: unknown[]): unknown[] {
+function toResponsesInput(messages: unknown[]): unknown[] | null {
   const input: unknown[] = []
   for (const message of messages) {
     if (!message || typeof message !== 'object') {
@@ -122,18 +139,21 @@ function toResponsesInput(messages: unknown[]): unknown[] {
     const record = message as Record<string, unknown>
 
     if (record.role === 'tool') {
+      const content = record.content
       input.push({
         type: 'function_call_output',
         call_id: record.tool_call_id,
-        output: typeof record.content === 'string' ? record.content : JSON.stringify(record.content ?? ''),
+        output: typeof content === 'string' ? content : JSON.stringify(content ?? ''),
       })
       continue
     }
 
     const toolCalls = record.tool_calls
-    if (record.role === 'assistant' && Array.isArray(toolCalls)) {
+    if (record.role === 'assistant' && Array.isArray(toolCalls) && toolCalls.length > 0) {
       if (record.content) {
-        input.push({ role: 'assistant', content: record.content })
+        const content = toResponsesContent(record.content)
+        if (content === null) return null
+        input.push({ role: 'assistant', content })
       }
       for (const call of toolCalls) {
         if (!call || typeof call !== 'object') continue
@@ -149,9 +169,47 @@ function toResponsesInput(messages: unknown[]): unknown[] {
       continue
     }
 
+    if (typeof record.content !== 'string' && record.content !== undefined && record.content !== null) {
+      const content = toResponsesContent(record.content)
+      if (content === null) return null
+      input.push({ ...record, content })
+      continue
+    }
+
     input.push(record)
   }
   return input
+}
+
+/**
+ * chat `content` (string or parts array) -> Responses `content`.
+ * Returns null for parts with no Responses equivalent.
+ */
+function toResponsesContent(content: unknown): unknown {
+  if (typeof content === 'string' || content == null) return content
+  if (!Array.isArray(content)) return null
+  const out: unknown[] = []
+  for (const part of content) {
+    if (!part || typeof part !== 'object') continue
+    const p = part as Record<string, unknown>
+    if (p.type === 'text' && typeof p.text === 'string') {
+      out.push({ type: 'input_text', text: p.text })
+    } else if (p.type === 'input_text' || p.type === 'input_image') {
+      out.push(part)
+    } else if (p.type === 'image_url') {
+      const raw = p.image_url
+      const url = typeof raw === 'string' ? raw : (raw as Record<string, unknown> | undefined)?.url
+      if (typeof url !== 'string') return null
+      const image: Record<string, unknown> = { type: 'input_image', image_url: url }
+      if (typeof (raw as Record<string, unknown> | undefined)?.detail === 'string') {
+        image.detail = (raw as Record<string, unknown>).detail
+      }
+      out.push(image)
+    } else {
+      return null
+    }
+  }
+  return out
 }
 
 function collectText(output: unknown): string {
@@ -164,9 +222,12 @@ function collectText(output: unknown): string {
     const content = record.content
     if (!Array.isArray(content)) continue
     for (const part of content) {
-      if (part && typeof part === 'object' && (part as Record<string, unknown>).type === 'output_text') {
-        const value = (part as Record<string, unknown>).text
-        if (typeof value === 'string') text += value
+      if (!part || typeof part !== 'object') continue
+      const p = part as Record<string, unknown>
+      if (p.type === 'output_text' && typeof p.text === 'string') {
+        text += p.text
+      } else if (p.type === 'refusal' && typeof p.refusal === 'string') {
+        text += p.refusal
       }
     }
   }
@@ -193,14 +254,33 @@ function finishReason(status: unknown): string {
   return status === 'incomplete' ? 'length' : 'stop'
 }
 
+/** Stable key for matching a streaming tool call across added/delta/done events. */
+function toolCallKey(outputIndex: unknown, item: Record<string, unknown>): string | null {
+  if (typeof outputIndex === 'number') return `index:${outputIndex}`
+  for (const field of ['item_id', 'call_id', 'id']) {
+    const value = item[field]
+    if (typeof value === 'string' && value) return `${field}:${value}`
+  }
+  return null
+}
+
 function mapUsage(usage: unknown): Record<string, unknown> | undefined {
   if (!usage || typeof usage !== 'object') return undefined
   const u = usage as Record<string, unknown>
-  return {
+  const mapped: Record<string, unknown> = {
     prompt_tokens: u.input_tokens ?? 0,
     completion_tokens: u.output_tokens ?? 0,
     total_tokens: u.total_tokens ?? 0,
   }
+  const inputDetails = u.input_tokens_details as Record<string, unknown> | undefined
+  if (inputDetails && typeof inputDetails.cached_tokens === 'number') {
+    mapped.prompt_tokens_details = { cached_tokens: inputDetails.cached_tokens }
+  }
+  const outputDetails = u.output_tokens_details as Record<string, unknown> | undefined
+  if (outputDetails && typeof outputDetails.reasoning_tokens === 'number') {
+    mapped.completion_tokens_details = { reasoning_tokens: outputDetails.reasoning_tokens }
+  }
+  return mapped
 }
 
 /** Non-streaming responses payload -> chat/completions payload. */
@@ -249,6 +329,11 @@ export class SseTranslator {
   private model = ''
   private roleSent = false
   private toolCallIndex = 0
+  // Incremental tool-call args keyed by the Responses output position (or item
+  // id when no index is present). A key is present once its opening frame has
+  // been emitted, so the terminal output_item.done can stay silent instead of
+  // re-emitting args the client already accumulated.
+  private readonly streamedToolCalls = new Map<string, number>()
   private readonly includeUsage: boolean
 
   // A chat/completions client sees usage only when it asked for it via
@@ -281,13 +366,19 @@ export class SseTranslator {
     }
 
     // A tool call arrives complete on output_item.done rather than as text
-    // deltas, so it is emitted as a single tool_calls frame. `index` must count
-    // tool calls only - numbering them by output position would leave gaps that
-    // clients accumulate into the wrong slot.
+    // deltas, so a model that sends no incremental args is emitted as a single
+    // tool_calls frame. `index` must count tool calls only - numbering them by
+    // output position would leave gaps that clients accumulate into the wrong
+    // slot. When incremental function_call_arguments.delta events were already
+    // streamed for this call, done stays silent so args are not duplicated.
     if (eventName === 'response.output_item.done') {
       const item = parsed.item as Record<string, unknown> | undefined
       if (!item || item.type !== 'function_call') return ''
+      const key = toolCallKey(parsed.output_index, item)
+      const known = key !== null ? this.streamedToolCalls.get(key) : undefined
+      if (known !== undefined) return ''
       const index = this.toolCallIndex++
+      if (key !== null) this.streamedToolCalls.set(key, index)
       return this.frame({
         tool_calls: [
           {
@@ -297,6 +388,39 @@ export class SseTranslator {
             function: { name: item.name, arguments: item.arguments ?? '{}' },
           },
         ],
+      }, null)
+    }
+
+    if (eventName === 'response.output_item.added') {
+      const item = parsed.item as Record<string, unknown> | undefined
+      if (!item || item.type !== 'function_call') return ''
+      const key = toolCallKey(parsed.output_index, item)
+      if (key !== null && this.streamedToolCalls.has(key)) return ''
+      const index = this.toolCallIndex++
+      if (key !== null) this.streamedToolCalls.set(key, index)
+      return this.frame({
+        tool_calls: [
+          {
+            index,
+            id: item.call_id ?? item.id,
+            type: 'function',
+            function: { name: item.name, arguments: '' },
+          },
+        ],
+      }, null)
+    }
+
+    if (eventName === 'response.function_call_arguments.delta') {
+      const delta = typeof parsed.delta === 'string' ? parsed.delta : ''
+      if (!delta) return ''
+      const key = toolCallKey(parsed.output_index, parsed as Record<string, unknown>)
+      let index = key !== null ? this.streamedToolCalls.get(key) : undefined
+      if (index === undefined) {
+        index = this.toolCallIndex++
+        if (key !== null) this.streamedToolCalls.set(key, index)
+      }
+      return this.frame({
+        tool_calls: [{ index, function: { arguments: delta } }],
       }, null)
     }
 
@@ -314,7 +438,7 @@ export class SseTranslator {
     }
 
     if (eventName === 'response.failed' || eventName === 'error') {
-      return `data: ${JSON.stringify({ error: parsed })}\n\ndata: [DONE]\n\n`
+      return `data: ${JSON.stringify({ error: (parsed.error ?? parsed) as unknown })}\n\ndata: [DONE]\n\n`
     }
 
     return ''

--- a/src/proxy/zen-responses.ts
+++ b/src/proxy/zen-responses.ts
@@ -1,0 +1,348 @@
+/**
+ * OpenCode Zen serves the Responses API. Its `/v1/chat/completions` route
+ * still exists, but returns 500 for the free contributor models, so a
+ * config-declared provider (which always speaks chat/completions) cannot
+ * reach Zen at all.
+ *
+ * This module translates chat/completions <-> responses for the Zen
+ * upstream only, so those models stay reachable through the pool.
+ */
+
+const CHAT_COMPLETIONS_SUFFIX = '/chat/completions'
+
+export function isChatCompletionsPath(path: string): boolean {
+  return path.endsWith(CHAT_COMPLETIONS_SUFFIX)
+}
+
+/** Rewrite `/zen/v1/chat/completions` -> `/zen/v1/responses`, query preserved. */
+export function toResponsesPath(url: string): string {
+  const [path, ...rest] = url.split('?')
+  const rewritten = path.slice(0, -CHAT_COMPLETIONS_SUFFIX.length) + '/responses'
+  return rest.length ? `${rewritten}?${rest.join('?')}` : rewritten
+}
+
+/**
+ * chat/completions request body -> responses request body.
+ * Returns null when the body is not parseable, so the caller can forward it
+ * untouched rather than fail the request.
+ */
+export function toResponsesRequestBody(body: Buffer): Buffer | null {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(body.toString('utf8'))
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+
+  const messages = parsed.messages
+  if (!Array.isArray(messages)) return null
+
+  const translated: Record<string, unknown> = {
+    model: parsed.model,
+    input: toResponsesInput(messages),
+  }
+  // The Responses API names the output budget differently. Both are passed
+  // through verbatim: a caller's budget is the caller's choice, even though
+  // reasoning models can spend all of it before emitting any text.
+  if (parsed.max_tokens != null) translated.max_output_tokens = parsed.max_tokens
+  if (parsed.max_completion_tokens != null) translated.max_output_tokens = parsed.max_completion_tokens
+  if (parsed.max_output_tokens != null) translated.max_output_tokens = parsed.max_output_tokens
+  for (const key of ['temperature', 'top_p', 'stream', 'metadata']) {
+    if (parsed[key] !== undefined) translated[key] = parsed[key]
+  }
+  // chat/completions object-form tool_choice nests the name under `function`,
+  // the same shape the tools array uses just below; the Responses API flattens
+  // it onto the choice. String forms mean the same in both APIs and pass
+  // through untouched.
+  if (parsed.tool_choice !== undefined) {
+    const choice = parsed.tool_choice
+    const record = choice && typeof choice === 'object' ? choice as Record<string, unknown> : null
+    const fn = record?.type === 'function' && record.function && typeof record.function === 'object'
+      ? record.function as Record<string, unknown>
+      : null
+    translated.tool_choice = fn && typeof fn.name === 'string'
+      ? { type: 'function', name: fn.name }
+      : choice
+  }
+  // chat/completions names the effort budget top-level `reasoning_effort`; the
+  // Responses API nests it under `reasoning.effort`.
+  if (parsed.reasoning_effort !== undefined) {
+    translated.reasoning = { effort: parsed.reasoning_effort }
+  }
+  // Structured output moves from `response_format` to `text.format`, and
+  // json_schema's inner envelope is unwrapped. type:"text" is the Responses
+  // default, so it is left unset rather than copied.
+  const responseFormat = parsed.response_format as Record<string, unknown> | undefined
+  if (responseFormat && typeof responseFormat === 'object') {
+    if (responseFormat.type === 'json_object') {
+      translated.text = { format: { type: 'json_object' } }
+    } else if (responseFormat.type === 'json_schema' && responseFormat.json_schema && typeof responseFormat.json_schema === 'object') {
+      translated.text = { format: { type: 'json_schema', ...(responseFormat.json_schema as Record<string, unknown>) } }
+    }
+  }
+  // chat/completions nests the schema under `function`; the Responses API
+  // expects it flattened onto the tool itself. Without this the upstream
+  // rejects the request with "`tools[0]` missing required field `name`".
+  if (Array.isArray(parsed.tools)) {
+    translated.tools = parsed.tools.map((tool) => {
+      if (!tool || typeof tool !== 'object') return tool
+      const record = tool as Record<string, unknown>
+      const fn = record.function
+      if (record.type !== 'function' || !fn || typeof fn !== 'object') return tool
+      const schema = fn as Record<string, unknown>
+      return {
+        type: 'function',
+        name: schema.name,
+        description: schema.description,
+        parameters: schema.parameters,
+        ...(schema.strict !== undefined ? { strict: schema.strict } : {}),
+      }
+    })
+  }
+  return Buffer.from(JSON.stringify(translated), 'utf8')
+}
+
+/**
+ * chat/completions `messages` -> Responses `input`.
+ *
+ * Plain messages pass through unchanged. The two that cannot are an assistant
+ * turn carrying `tool_calls` and a `role: "tool"` result: the Responses API
+ * models those as standalone `function_call` / `function_call_output` items
+ * rather than as message fields, so a conversation replayed without this
+ * translation loses every tool exchange.
+ */
+function toResponsesInput(messages: unknown[]): unknown[] {
+  const input: unknown[] = []
+  for (const message of messages) {
+    if (!message || typeof message !== 'object') {
+      input.push(message)
+      continue
+    }
+    const record = message as Record<string, unknown>
+
+    if (record.role === 'tool') {
+      input.push({
+        type: 'function_call_output',
+        call_id: record.tool_call_id,
+        output: typeof record.content === 'string' ? record.content : JSON.stringify(record.content ?? ''),
+      })
+      continue
+    }
+
+    const toolCalls = record.tool_calls
+    if (record.role === 'assistant' && Array.isArray(toolCalls)) {
+      if (record.content) {
+        input.push({ role: 'assistant', content: record.content })
+      }
+      for (const call of toolCalls) {
+        if (!call || typeof call !== 'object') continue
+        const entry = call as Record<string, unknown>
+        const fn = (entry.function ?? {}) as Record<string, unknown>
+        input.push({
+          type: 'function_call',
+          call_id: entry.id,
+          name: fn.name,
+          arguments: typeof fn.arguments === 'string' ? fn.arguments : JSON.stringify(fn.arguments ?? {}),
+        })
+      }
+      continue
+    }
+
+    input.push(record)
+  }
+  return input
+}
+
+function collectText(output: unknown): string {
+  if (!Array.isArray(output)) return ''
+  let text = ''
+  for (const item of output) {
+    if (!item || typeof item !== 'object') continue
+    const record = item as Record<string, unknown>
+    if (record.type !== 'message') continue
+    const content = record.content
+    if (!Array.isArray(content)) continue
+    for (const part of content) {
+      if (part && typeof part === 'object' && (part as Record<string, unknown>).type === 'output_text') {
+        const value = (part as Record<string, unknown>).text
+        if (typeof value === 'string') text += value
+      }
+    }
+  }
+  return text
+}
+
+function collectToolCalls(output: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(output)) return []
+  const calls: Record<string, unknown>[] = []
+  for (const item of output) {
+    if (!item || typeof item !== 'object') continue
+    const record = item as Record<string, unknown>
+    if (record.type !== 'function_call') continue
+    calls.push({
+      id: record.call_id ?? record.id,
+      type: 'function',
+      function: { name: record.name, arguments: record.arguments ?? '{}' },
+    })
+  }
+  return calls
+}
+
+function finishReason(status: unknown): string {
+  return status === 'incomplete' ? 'length' : 'stop'
+}
+
+function mapUsage(usage: unknown): Record<string, unknown> | undefined {
+  if (!usage || typeof usage !== 'object') return undefined
+  const u = usage as Record<string, unknown>
+  return {
+    prompt_tokens: u.input_tokens ?? 0,
+    completion_tokens: u.output_tokens ?? 0,
+    total_tokens: u.total_tokens ?? 0,
+  }
+}
+
+/** Non-streaming responses payload -> chat/completions payload. */
+export function toChatCompletion(payload: string): string {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(payload)
+  } catch {
+    return payload
+  }
+  // Upstream errors are already shaped as {error: ...}; pass them through so
+  // the client sees the real failure rather than an empty completion.
+  if (!parsed || typeof parsed !== 'object' || parsed.error) return payload
+  if (parsed.object !== 'response') return payload
+
+  const toolCalls = collectToolCalls(parsed.output)
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    content: collectText(parsed.output) || null,
+  }
+  if (toolCalls.length) message.tool_calls = toolCalls
+
+  return JSON.stringify({
+    id: parsed.id,
+    object: 'chat.completion',
+    created: parsed.created_at ?? Math.floor(Date.now() / 1000),
+    model: parsed.model,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: toolCalls.length ? 'tool_calls' : finishReason(parsed.status),
+      },
+    ],
+    usage: mapUsage(parsed.usage),
+  })
+}
+
+/**
+ * Translate one Responses SSE event into zero or more chat.completion.chunk
+ * SSE frames. Stateful only in the sense that the caller feeds events in
+ * order; `id`/`model` are carried by the caller.
+ */
+export class SseTranslator {
+  private id = 'chatcmpl-zen'
+  private model = ''
+  private roleSent = false
+  private toolCallIndex = 0
+  private readonly includeUsage: boolean
+
+  // A chat/completions client sees usage only when it asked for it via
+  // stream_options.include_usage; the Responses stream always carries it in
+  // response.completed, so we must remember the client's choice and emit a
+  // usage chunk only when it opted in.
+  constructor(includeUsage = false) {
+    this.includeUsage = includeUsage
+  }
+
+  translate(eventName: string, data: string): string {
+    let parsed: Record<string, unknown>
+    try {
+      parsed = JSON.parse(data)
+    } catch {
+      return ''
+    }
+
+    if (eventName === 'response.created' || eventName === 'response.in_progress') {
+      const response = parsed.response as Record<string, unknown> | undefined
+      if (response) {
+        if (typeof response.id === 'string') this.id = response.id
+        if (typeof response.model === 'string') this.model = response.model
+      }
+      if (eventName === 'response.created' && !this.roleSent) {
+        this.roleSent = true
+        return this.frame({ role: 'assistant', content: '' }, null)
+      }
+      return ''
+    }
+
+    // A tool call arrives complete on output_item.done rather than as text
+    // deltas, so it is emitted as a single tool_calls frame. `index` must count
+    // tool calls only - numbering them by output position would leave gaps that
+    // clients accumulate into the wrong slot.
+    if (eventName === 'response.output_item.done') {
+      const item = parsed.item as Record<string, unknown> | undefined
+      if (!item || item.type !== 'function_call') return ''
+      const index = this.toolCallIndex++
+      return this.frame({
+        tool_calls: [
+          {
+            index,
+            id: item.call_id ?? item.id,
+            type: 'function',
+            function: { name: item.name, arguments: item.arguments ?? '{}' },
+          },
+        ],
+      }, null)
+    }
+
+    if (eventName === 'response.output_text.delta') {
+      const delta = typeof parsed.delta === 'string' ? parsed.delta : ''
+      if (!delta) return ''
+      return this.frame({ content: delta }, null)
+    }
+
+    if (eventName === 'response.completed' || eventName === 'response.incomplete') {
+      const response = parsed.response as Record<string, unknown> | undefined
+      const reason = this.toolCallIndex > 0 ? 'tool_calls' : finishReason(response?.status)
+      const usage = this.includeUsage ? mapUsage(response?.usage) : undefined
+      return this.frame({}, reason) + this.usageFrame(usage) + 'data: [DONE]\n\n'
+    }
+
+    if (eventName === 'response.failed' || eventName === 'error') {
+      return `data: ${JSON.stringify({ error: parsed })}\n\ndata: [DONE]\n\n`
+    }
+
+    return ''
+  }
+
+  private frame(delta: Record<string, unknown>, reason: string | null): string {
+    const chunk = {
+      id: this.id,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: this.model,
+      choices: [{ index: 0, delta, finish_reason: reason }],
+    }
+    return `data: ${JSON.stringify(chunk)}\n\n`
+  }
+
+  // Usage is reported in a dedicated final frame with an empty choices array,
+  // the shape a chat/completions client expects when include_usage is set.
+  private usageFrame(usage: Record<string, unknown> | undefined): string {
+    if (!usage) return ''
+    const chunk = {
+      id: this.id,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: this.model,
+      choices: [],
+      usage,
+    }
+    return `data: ${JSON.stringify(chunk)}\n\n`
+  }
+}


### PR DESCRIPTION
## Problem

Zen's free models are split across two protocols. Measured against the upstream directly, with the proxy bypassed:

| model | `/v1/chat/completions` | `/v1/responses` |
|---|---|---|
| `laguna-s-2.1-free` | **200** | 500 |
| `nemotron-3-ultra-free` | **200** | 500 |
| `muse-spark-1.2-contributor-free` | 500 | **200** |
| `muse-spark-1.3-contributor-free` | 500 | **200** |
| `claude-haiku-4-5` (paid, with key) | 401 CreditsError | — |
| unknown path | 404 | 404 |

The endpoint itself is healthy — it returns a correct 401 for a paid model without credit and 404 for an unknown path. Individual models simply serve one protocol or the other, and auth makes no difference (`/responses` returns 200 with and without an `Authorization` header).

A config-declared provider always speaks chat/completions, so the muse contributor models are unreachable through the pool, while laguna and nemotron work. Worse, every failed attempt is a 5xx on all keys, so it also trips their circuit breakers and takes Go-upstream traffic down with it.

## Change

A Zen chat/completions request is sent **natively first**. Only when the upstream answers 500 is it re-sent translated to `/responses`, and the outcome is remembered per model so later requests go straight to the endpoint that works.

No model allowlist, and no per-request pre-flight probe — that would double latency and still race. Cost is one extra round trip on the first request for a model that needs translating. If Zen restores chat/completions, a restart re-learns it.

The protocol-switch retry deliberately does not consume a key-failover attempt: it is not a key failure, and eating an attempt would starve a genuinely failing key of its retry.

The translation, when it applies:

| chat/completions | Responses API |
|---|---|
| `messages` | `input` |
| `max_tokens` / `max_completion_tokens` | `max_output_tokens` |
| `tools[].function.{name,…}` | `tools[].{name,…}` (flattened) |
| object-form `tool_choice` | flattened name |
| `reasoning_effort` | `reasoning: { effort }` |
| assistant turn with `tool_calls` | standalone `function_call` items |
| `role: "tool"` result | `function_call_output` item |
| response `output[]` | `choices[0].message` (+ `tool_calls`) |
| `response.*` SSE | `chat.completion.chunk` frames |

Tool exchanges need translating because the Responses API models a call and its result as standalone items rather than as message fields — a replayed conversation would otherwise lose every tool turn. A streamed tool call is emitted as one frame on `output_item.done`, indexed by tool-call count rather than output position, so clients accumulate arguments into the right slot.

`parseJsonUsage` also learns the Responses SSE shape (`response.completed` → `response.usage`). Without it, translated streaming traffic records no tokens and dashboard cost goes dark.

Everything is gated on the `/zen` path; the Go upstream is untouched. Unparseable bodies fail open and are forwarded unchanged.

## Verification

Against a live router:

- All four free models above answer 200 on the same chat/completions endpoint — two served natively, two translated.
- A prompt requiring a file read completes its tool call and returns the contents, streaming, on `muse-spark-1.3-contributor-free`.
- The second request for a memoised model makes exactly one upstream call.
- Usage is recorded for translated streams (previously `tokens: null`).
- No regression on the Go upstream or on the direct `opencode` provider.
- `npm run typecheck` passes.
