### PR TITLE
fix(proxy): forward x-opencode-session header upstream

### DIFF
--- a/src/proxy/header-passthrough.ts
+++ b/src/proxy/header-passthrough.ts
@@ -16,6 +16,7 @@ const HOP_BY_HOP = new Set([
 const FORWARDED_HEADERS = new Set([
   'accept', 'accept-encoding', 'accept-language', 'content-type',
   'anthropic-version', 'anthropic-beta',
+  'x-opencode-session',
 ])
 
 export function isCacheHeader(name: string): boolean {


### PR DESCRIPTION
Upstream now requires the x-opencode-session header (one stable ID per conversation) on Go requests for service optimization, and requests missing it may error. The proxy's header allowlist was stripping it before forwarding. This adds x-opencode-session to FORWARDED_HEADERS so a client-supplied value passes through byte-for-byte to both Go and Zen upstreams (strict forward-only, nothing synthesized). Verified with npm run typecheck && npm run build; daemon restarted and healthy.